### PR TITLE
Provide EPL1 and EPL2 features.

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -1,204 +1,277 @@
-Eclipse Public License - v 1.0
+Eclipse Public License - v 2.0
 
-THE ACCOMPANYING PROGRAM IS PROVIDED UNDER THE TERMS OF THIS ECLIPSE PUBLIC
-LICENSE ("AGREEMENT"). ANY USE, REPRODUCTION OR DISTRIBUTION OF THE PROGRAM
-CONSTITUTES RECIPIENT'S ACCEPTANCE OF THIS AGREEMENT.
+    THE ACCOMPANYING PROGRAM IS PROVIDED UNDER THE TERMS OF THIS ECLIPSE
+    PUBLIC LICENSE ("AGREEMENT"). ANY USE, REPRODUCTION OR DISTRIBUTION
+    OF THE PROGRAM CONSTITUTES RECIPIENT'S ACCEPTANCE OF THIS AGREEMENT.
 
 1. DEFINITIONS
 
 "Contribution" means:
 
-a) in the case of the initial Contributor, the initial code and documentation
-   distributed under this Agreement, and
-b) in the case of each subsequent Contributor:
-    i) changes to the Program, and
-   ii) additions to the Program;
+  a) in the case of the initial Contributor, the initial content
+     Distributed under this Agreement, and
 
-   where such changes and/or additions to the Program originate from and are
-   distributed by that particular Contributor. A Contribution 'originates'
-   from a Contributor if it was added to the Program by such Contributor
-   itself or anyone acting on such Contributor's behalf. Contributions do not
-   include additions to the Program which: (i) are separate modules of
-   software distributed in conjunction with the Program under their own
-   license agreement, and (ii) are not derivative works of the Program.
+  b) in the case of each subsequent Contributor:
+     i) changes to the Program, and
+     ii) additions to the Program;
+  where such changes and/or additions to the Program originate from
+  and are Distributed by that particular Contributor. A Contribution
+  "originates" from a Contributor if it was added to the Program by
+  such Contributor itself or anyone acting on such Contributor's behalf.
+  Contributions do not include changes or additions to the Program that
+  are not Modified Works.
 
-"Contributor" means any person or entity that distributes the Program.
+"Contributor" means any person or entity that Distributes the Program.
 
-"Licensed Patents" mean patent claims licensable by a Contributor which are
-necessarily infringed by the use or sale of its Contribution alone or when
-combined with the Program.
+"Licensed Patents" mean patent claims licensable by a Contributor which
+are necessarily infringed by the use or sale of its Contribution alone
+or when combined with the Program.
 
-"Program" means the Contributions distributed in accordance with this
+"Program" means the Contributions Distributed in accordance with this
 Agreement.
 
-"Recipient" means anyone who receives the Program under this Agreement,
-including all Contributors.
+"Recipient" means anyone who receives the Program under this Agreement
+or any Secondary License (as applicable), including Contributors.
+
+"Derivative Works" shall mean any work, whether in Source Code or other
+form, that is based on (or derived from) the Program and for which the
+editorial revisions, annotations, elaborations, or other modifications
+represent, as a whole, an original work of authorship.
+
+"Modified Works" shall mean any work in Source Code or other form that
+results from an addition to, deletion from, or modification of the
+contents of the Program, including, for purposes of clarity any new file
+in Source Code form that contains any contents of the Program. Modified
+Works shall not include works that contain only declarations,
+interfaces, types, classes, structures, or files of the Program solely
+in each case in order to link to, bind by name, or subclass the Program
+or Modified Works thereof.
+
+"Distribute" means the acts of a) distributing or b) making available
+in any manner that enables the transfer of a copy.
+
+"Source Code" means the form of a Program preferred for making
+modifications, including but not limited to software source code,
+documentation source, and configuration files.
+
+"Secondary License" means either the GNU General Public License,
+Version 2.0, or any later versions of that license, including any
+exceptions or additional permissions as identified by the initial
+Contributor.
 
 2. GRANT OF RIGHTS
-  a) Subject to the terms of this Agreement, each Contributor hereby grants
-     Recipient a non-exclusive, worldwide, royalty-free copyright license to
-     reproduce, prepare derivative works of, publicly display, publicly
-     perform, distribute and sublicense the Contribution of such Contributor,
-     if any, and such derivative works, in source code and object code form.
-  b) Subject to the terms of this Agreement, each Contributor hereby grants
-     Recipient a non-exclusive, worldwide, royalty-free patent license under
-     Licensed Patents to make, use, sell, offer to sell, import and otherwise
-     transfer the Contribution of such Contributor, if any, in source code and
-     object code form. This patent license shall apply to the combination of
-     the Contribution and the Program if, at the time the Contribution is
-     added by the Contributor, such addition of the Contribution causes such
-     combination to be covered by the Licensed Patents. The patent license
-     shall not apply to any other combinations which include the Contribution.
-     No hardware per se is licensed hereunder.
-  c) Recipient understands that although each Contributor grants the licenses
-     to its Contributions set forth herein, no assurances are provided by any
-     Contributor that the Program does not infringe the patent or other
-     intellectual property rights of any other entity. Each Contributor
-     disclaims any liability to Recipient for claims brought by any other
-     entity based on infringement of intellectual property rights or
-     otherwise. As a condition to exercising the rights and licenses granted
-     hereunder, each Recipient hereby assumes sole responsibility to secure
-     any other intellectual property rights needed, if any. For example, if a
-     third party patent license is required to allow Recipient to distribute
-     the Program, it is Recipient's responsibility to acquire that license
-     before distributing the Program.
-  d) Each Contributor represents that to its knowledge it has sufficient
-     copyright rights in its Contribution, if any, to grant the copyright
-     license set forth in this Agreement.
+
+  a) Subject to the terms of this Agreement, each Contributor hereby
+  grants Recipient a non-exclusive, worldwide, royalty-free copyright
+  license to reproduce, prepare Derivative Works of, publicly display,
+  publicly perform, Distribute and sublicense the Contribution of such
+  Contributor, if any, and such Derivative Works.
+
+  b) Subject to the terms of this Agreement, each Contributor hereby
+  grants Recipient a non-exclusive, worldwide, royalty-free patent
+  license under Licensed Patents to make, use, sell, offer to sell,
+  import and otherwise transfer the Contribution of such Contributor,
+  if any, in Source Code or other form. This patent license shall
+  apply to the combination of the Contribution and the Program if, at
+  the time the Contribution is added by the Contributor, such addition
+  of the Contribution causes such combination to be covered by the
+  Licensed Patents. The patent license shall not apply to any other
+  combinations which include the Contribution. No hardware per se is
+  licensed hereunder.
+
+  c) Recipient understands that although each Contributor grants the
+  licenses to its Contributions set forth herein, no assurances are
+  provided by any Contributor that the Program does not infringe the
+  patent or other intellectual property rights of any other entity.
+  Each Contributor disclaims any liability to Recipient for claims
+  brought by any other entity based on infringement of intellectual
+  property rights or otherwise. As a condition to exercising the
+  rights and licenses granted hereunder, each Recipient hereby
+  assumes sole responsibility to secure any other intellectual
+  property rights needed, if any. For example, if a third party
+  patent license is required to allow Recipient to Distribute the
+  Program, it is Recipient's responsibility to acquire that license
+  before distributing the Program.
+
+  d) Each Contributor represents that to its knowledge it has
+  sufficient copyright rights in its Contribution, if any, to grant
+  the copyright license set forth in this Agreement.
+
+  e) Notwithstanding the terms of any Secondary License, no
+  Contributor makes additional grants to any Recipient (other than
+  those set forth in this Agreement) as a result of such Recipient's
+  receipt of the Program under the terms of a Secondary License
+  (if permitted under the terms of Section 3).
 
 3. REQUIREMENTS
 
-A Contributor may choose to distribute the Program in object code form under
-its own license agreement, provided that:
+3.1 If a Contributor Distributes the Program in any form, then:
 
-  a) it complies with the terms and conditions of this Agreement; and
-  b) its license agreement:
-      i) effectively disclaims on behalf of all Contributors all warranties
-         and conditions, express and implied, including warranties or
-         conditions of title and non-infringement, and implied warranties or
-         conditions of merchantability and fitness for a particular purpose;
-     ii) effectively excludes on behalf of all Contributors all liability for
-         damages, including direct, indirect, special, incidental and
-         consequential damages, such as lost profits;
-    iii) states that any provisions which differ from this Agreement are
-         offered by that Contributor alone and not by any other party; and
-     iv) states that source code for the Program is available from such
-         Contributor, and informs licensees how to obtain it in a reasonable
-         manner on or through a medium customarily used for software exchange.
+  a) the Program must also be made available as Source Code, in
+  accordance with section 3.2, and the Contributor must accompany
+  the Program with a statement that the Source Code for the Program
+  is available under this Agreement, and informs Recipients how to
+  obtain it in a reasonable manner on or through a medium customarily
+  used for software exchange; and
 
-When the Program is made available in source code form:
+  b) the Contributor may Distribute the Program under a license
+  different than this Agreement, provided that such license:
+     i) effectively disclaims on behalf of all other Contributors all
+     warranties and conditions, express and implied, including
+     warranties or conditions of title and non-infringement, and
+     implied warranties or conditions of merchantability and fitness
+     for a particular purpose;
 
-  a) it must be made available under this Agreement; and
-  b) a copy of this Agreement must be included with each copy of the Program.
-     Contributors may not remove or alter any copyright notices contained
-     within the Program.
+     ii) effectively excludes on behalf of all other Contributors all
+     liability for damages, including direct, indirect, special,
+     incidental and consequential damages, such as lost profits;
 
-Each Contributor must identify itself as the originator of its Contribution,
-if
-any, in a manner that reasonably allows subsequent Recipients to identify the
-originator of the Contribution.
+     iii) does not attempt to limit or alter the recipients' rights
+     in the Source Code under section 3.2; and
+
+     iv) requires any subsequent distribution of the Program by any
+     party to be under a license that satisfies the requirements
+     of this section 3.
+
+3.2 When the Program is Distributed as Source Code:
+
+  a) it must be made available under this Agreement, or if the
+  Program (i) is combined with other material in a separate file or
+  files made available under a Secondary License, and (ii) the initial
+  Contributor attached to the Source Code the notice described in
+  Exhibit A of this Agreement, then the Program may be made available
+  under the terms of such Secondary Licenses, and
+
+  b) a copy of this Agreement must be included with each copy of
+  the Program.
+
+3.3 Contributors may not remove or alter any copyright, patent,
+trademark, attribution notices, disclaimers of warranty, or limitations
+of liability ("notices") contained within the Program from any copy of
+the Program which they Distribute, provided that Contributors may add
+their own appropriate notices.
 
 4. COMMERCIAL DISTRIBUTION
 
-Commercial distributors of software may accept certain responsibilities with
-respect to end users, business partners and the like. While this license is
-intended to facilitate the commercial use of the Program, the Contributor who
-includes the Program in a commercial product offering should do so in a manner
-which does not create potential liability for other Contributors. Therefore,
-if a Contributor includes the Program in a commercial product offering, such
-Contributor ("Commercial Contributor") hereby agrees to defend and indemnify
-every other Contributor ("Indemnified Contributor") against any losses,
-damages and costs (collectively "Losses") arising from claims, lawsuits and
-other legal actions brought by a third party against the Indemnified
-Contributor to the extent caused by the acts or omissions of such Commercial
-Contributor in connection with its distribution of the Program in a commercial
-product offering. The obligations in this section do not apply to any claims
-or Losses relating to any actual or alleged intellectual property
-infringement. In order to qualify, an Indemnified Contributor must:
-a) promptly notify the Commercial Contributor in writing of such claim, and
-b) allow the Commercial Contributor to control, and cooperate with the
-Commercial Contributor in, the defense and any related settlement
-negotiations. The Indemnified Contributor may participate in any such claim at
-its own expense.
+Commercial distributors of software may accept certain responsibilities
+with respect to end users, business partners and the like. While this
+license is intended to facilitate the commercial use of the Program,
+the Contributor who includes the Program in a commercial product
+offering should do so in a manner which does not create potential
+liability for other Contributors. Therefore, if a Contributor includes
+the Program in a commercial product offering, such Contributor
+("Commercial Contributor") hereby agrees to defend and indemnify every
+other Contributor ("Indemnified Contributor") against any losses,
+damages and costs (collectively "Losses") arising from claims, lawsuits
+and other legal actions brought by a third party against the Indemnified
+Contributor to the extent caused by the acts or omissions of such
+Commercial Contributor in connection with its distribution of the Program
+in a commercial product offering. The obligations in this section do not
+apply to any claims or Losses relating to any actual or alleged
+intellectual property infringement. In order to qualify, an Indemnified
+Contributor must: a) promptly notify the Commercial Contributor in
+writing of such claim, and b) allow the Commercial Contributor to control,
+and cooperate with the Commercial Contributor in, the defense and any
+related settlement negotiations. The Indemnified Contributor may
+participate in any such claim at its own expense.
 
-For example, a Contributor might include the Program in a commercial product
-offering, Product X. That Contributor is then a Commercial Contributor. If
-that Commercial Contributor then makes performance claims, or offers
-warranties related to Product X, those performance claims and warranties are
-such Commercial Contributor's responsibility alone. Under this section, the
-Commercial Contributor would have to defend claims against the other
-Contributors related to those performance claims and warranties, and if a
-court requires any other Contributor to pay any damages as a result, the
-Commercial Contributor must pay those damages.
+For example, a Contributor might include the Program in a commercial
+product offering, Product X. That Contributor is then a Commercial
+Contributor. If that Commercial Contributor then makes performance
+claims, or offers warranties related to Product X, those performance
+claims and warranties are such Commercial Contributor's responsibility
+alone. Under this section, the Commercial Contributor would have to
+defend claims against the other Contributors related to those performance
+claims and warranties, and if a court requires any other Contributor to
+pay any damages as a result, the Commercial Contributor must pay
+those damages.
 
 5. NO WARRANTY
 
-EXCEPT AS EXPRESSLY SET FORTH IN THIS AGREEMENT, THE PROGRAM IS PROVIDED ON AN
-"AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, EITHER EXPRESS OR
-IMPLIED INCLUDING, WITHOUT LIMITATION, ANY WARRANTIES OR CONDITIONS OF TITLE,
-NON-INFRINGEMENT, MERCHANTABILITY OR FITNESS FOR A PARTICULAR PURPOSE. Each
-Recipient is solely responsible for determining the appropriateness of using
-and distributing the Program and assumes all risks associated with its
-exercise of rights under this Agreement , including but not limited to the
-risks and costs of program errors, compliance with applicable laws, damage to
-or loss of data, programs or equipment, and unavailability or interruption of
-operations.
+EXCEPT AS EXPRESSLY SET FORTH IN THIS AGREEMENT, AND TO THE EXTENT
+PERMITTED BY APPLICABLE LAW, THE PROGRAM IS PROVIDED ON AN "AS IS"
+BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, EITHER EXPRESS OR
+IMPLIED INCLUDING, WITHOUT LIMITATION, ANY WARRANTIES OR CONDITIONS OF
+TITLE, NON-INFRINGEMENT, MERCHANTABILITY OR FITNESS FOR A PARTICULAR
+PURPOSE. Each Recipient is solely responsible for determining the
+appropriateness of using and distributing the Program and assumes all
+risks associated with its exercise of rights under this Agreement,
+including but not limited to the risks and costs of program errors,
+compliance with applicable laws, damage to or loss of data, programs
+or equipment, and unavailability or interruption of operations.
 
 6. DISCLAIMER OF LIABILITY
 
-EXCEPT AS EXPRESSLY SET FORTH IN THIS AGREEMENT, NEITHER RECIPIENT NOR ANY
-CONTRIBUTORS SHALL HAVE ANY LIABILITY FOR ANY DIRECT, INDIRECT, INCIDENTAL,
-SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING WITHOUT LIMITATION
-LOST PROFITS), HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+EXCEPT AS EXPRESSLY SET FORTH IN THIS AGREEMENT, AND TO THE EXTENT
+PERMITTED BY APPLICABLE LAW, NEITHER RECIPIENT NOR ANY CONTRIBUTORS
+SHALL HAVE ANY LIABILITY FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL,
+EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING WITHOUT LIMITATION LOST
+PROFITS), HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
 CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
 ARISING IN ANY WAY OUT OF THE USE OR DISTRIBUTION OF THE PROGRAM OR THE
-EXERCISE OF ANY RIGHTS GRANTED HEREUNDER, EVEN IF ADVISED OF THE POSSIBILITY
-OF SUCH DAMAGES.
+EXERCISE OF ANY RIGHTS GRANTED HEREUNDER, EVEN IF ADVISED OF THE
+POSSIBILITY OF SUCH DAMAGES.
 
 7. GENERAL
 
 If any provision of this Agreement is invalid or unenforceable under
-applicable law, it shall not affect the validity or enforceability of the
-remainder of the terms of this Agreement, and without further action by the
-parties hereto, such provision shall be reformed to the minimum extent
-necessary to make such provision valid and enforceable.
+applicable law, it shall not affect the validity or enforceability of
+the remainder of the terms of this Agreement, and without further
+action by the parties hereto, such provision shall be reformed to the
+minimum extent necessary to make such provision valid and enforceable.
 
-If Recipient institutes patent litigation against any entity (including a
-cross-claim or counterclaim in a lawsuit) alleging that the Program itself
-(excluding combinations of the Program with other software or hardware)
-infringes such Recipient's patent(s), then such Recipient's rights granted
-under Section 2(b) shall terminate as of the date such litigation is filed.
+If Recipient institutes patent litigation against any entity
+(including a cross-claim or counterclaim in a lawsuit) alleging that the
+Program itself (excluding combinations of the Program with other software
+or hardware) infringes such Recipient's patent(s), then such Recipient's
+rights granted under Section 2(b) shall terminate as of the date such
+litigation is filed.
 
-All Recipient's rights under this Agreement shall terminate if it fails to
-comply with any of the material terms or conditions of this Agreement and does
-not cure such failure in a reasonable period of time after becoming aware of
-such noncompliance. If all Recipient's rights under this Agreement terminate,
-Recipient agrees to cease use and distribution of the Program as soon as
-reasonably practicable. However, Recipient's obligations under this Agreement
-and any licenses granted by Recipient relating to the Program shall continue
-and survive.
+All Recipient's rights under this Agreement shall terminate if it
+fails to comply with any of the material terms or conditions of this
+Agreement and does not cure such failure in a reasonable period of
+time after becoming aware of such noncompliance. If all Recipient's
+rights under this Agreement terminate, Recipient agrees to cease use
+and distribution of the Program as soon as reasonably practicable.
+However, Recipient's obligations under this Agreement and any licenses
+granted by Recipient relating to the Program shall continue and survive.
 
-Everyone is permitted to copy and distribute copies of this Agreement, but in
-order to avoid inconsistency the Agreement is copyrighted and may only be
-modified in the following manner. The Agreement Steward reserves the right to
-publish new versions (including revisions) of this Agreement from time to
-time. No one other than the Agreement Steward has the right to modify this
-Agreement. The Eclipse Foundation is the initial Agreement Steward. The
-Eclipse Foundation may assign the responsibility to serve as the Agreement
-Steward to a suitable separate entity. Each new version of the Agreement will
-be given a distinguishing version number. The Program (including
-Contributions) may always be distributed subject to the version of the
-Agreement under which it was received. In addition, after a new version of the
-Agreement is published, Contributor may elect to distribute the Program
-(including its Contributions) under the new version. Except as expressly
-stated in Sections 2(a) and 2(b) above, Recipient receives no rights or
-licenses to the intellectual property of any Contributor under this Agreement,
-whether expressly, by implication, estoppel or otherwise. All rights in the
-Program not expressly granted under this Agreement are reserved.
+Everyone is permitted to copy and distribute copies of this Agreement,
+but in order to avoid inconsistency the Agreement is copyrighted and
+may only be modified in the following manner. The Agreement Steward
+reserves the right to publish new versions (including revisions) of
+this Agreement from time to time. No one other than the Agreement
+Steward has the right to modify this Agreement. The Eclipse Foundation
+is the initial Agreement Steward. The Eclipse Foundation may assign the
+responsibility to serve as the Agreement Steward to a suitable separate
+entity. Each new version of the Agreement will be given a distinguishing
+version number. The Program (including Contributions) may always be
+Distributed subject to the version of the Agreement under which it was
+received. In addition, after a new version of the Agreement is published,
+Contributor may elect to Distribute the Program (including its
+Contributions) under the new version.
 
-This Agreement is governed by the laws of the State of New York and the
-intellectual property laws of the United States of America. No party to this
-Agreement will bring a legal action under this Agreement more than one year
-after the cause of action arose. Each party waives its rights to a jury trial in
-any resulting litigation.
+Except as expressly stated in Sections 2(a) and 2(b) above, Recipient
+receives no rights or licenses to the intellectual property of any
+Contributor under this Agreement, whether expressly, by implication,
+estoppel or otherwise. All rights in the Program not expressly granted
+under this Agreement are reserved. Nothing in this Agreement is intended
+to be enforceable by any entity that is not a Contributor or Recipient.
+No third-party beneficiary rights are created under this Agreement.
 
+Exhibit A - Form of Secondary Licenses Notice
+
+"This Source Code may also be made available under the following 
+Secondary Licenses when the conditions for such availability set forth 
+in the Eclipse Public License, v. 2.0 are satisfied: {name license(s),
+version(s), and exceptions or additional permissions here}."
+
+  Simply including a copy of this Agreement, including this Exhibit A
+  is not sufficient to license the Source Code under Secondary Licenses.
+
+  If it is not possible or desirable to put the notice in a particular
+  file, then You may include the notice in a location (such as a LICENSE
+  file in a relevant directory) where a recipient would be likely to
+  look for such a notice.
+
+  You may add additional accurate notices of copyright ownership.

--- a/features/org.palladiosimulator.branding.feature/feature.xml
+++ b/features/org.palladiosimulator.branding.feature/feature.xml
@@ -3,9 +3,7 @@
       id="org.palladiosimulator.branding.feature"
       label="Branding Feature"
       version="2.0.0"
-      plugin="org.palladiosimulator.branding"
-      license-feature="org.palladiosimulator.license"
-      license-feature-version="2.0.0">
+      plugin="org.palladiosimulator.branding">
 
    <description>
       Branding plugins commonly shared between Palladio features and bundles.

--- a/features/org.palladiosimulator.license.epl2/.project
+++ b/features/org.palladiosimulator.license.epl2/.project
@@ -1,0 +1,17 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<projectDescription>
+	<name>org.palladiosimulator.license.epl2</name>
+	<comment></comment>
+	<projects>
+	</projects>
+	<buildSpec>
+		<buildCommand>
+			<name>org.eclipse.pde.FeatureBuilder</name>
+			<arguments>
+			</arguments>
+		</buildCommand>
+	</buildSpec>
+	<natures>
+		<nature>org.eclipse.pde.FeatureNature</nature>
+	</natures>
+</projectDescription>

--- a/features/org.palladiosimulator.license.epl2/.settings/org.eclipse.core.resources.prefs
+++ b/features/org.palladiosimulator.license.epl2/.settings/org.eclipse.core.resources.prefs
@@ -1,0 +1,2 @@
+eclipse.preferences.version=1
+encoding/feature.properties=UTF-8

--- a/features/org.palladiosimulator.license.epl2/build.properties
+++ b/features/org.palladiosimulator.license.epl2/build.properties
@@ -1,0 +1,3 @@
+bin.includes = feature.xml,\
+               feature.properties,\
+               build.properties

--- a/features/org.palladiosimulator.license.epl2/feature.properties
+++ b/features/org.palladiosimulator.license.epl2/feature.properties
@@ -1,0 +1,308 @@
+# feature.properties
+# contains externalized strings for feature.xml
+# "%foo" in feature.xml corresponds to the key "foo" in this file
+# java.io.Properties file (ISO 8859-1 with "\" escapes)
+# This file should be translated.
+
+providerName=palladiosimulator.org
+
+# "copyrightURL" property - text of the "Feature Update Copyright URL"
+copyrightURL=http://www.palladio-simulator.com/about_palladio/contact/
+
+# "copyright" property - text of the "Feature Update Copyright"
+copyright=\
+Palladio Bench, Palladio Component Model\n\
+Copyright 2005-2019,\n\
+Karlsruhe Institute of Technology (KIT), Software Design and Quality, Karlsruhe, Germany\n\
+University of Stuttgart, Institute of Software Technology, Stuttgart, Germany\n\
+Chemnitz University of Technology, Software Engineering Chair, Chemnitz, Germany\n\
+Paderborn University, Heinz Nixdorf Institute, Software Engineering, Paderborn, Germany\n\
+FZI Research Center for Information Technology, Karlsruhe, Germany\n\
+\n\
+http://www.palladio-simulator.com\n
+
+# "licenseURL" property - URL of the "Feature License"
+# do not translate value - just change to point to a locale-specific HTML page
+licenseURL=https://www.eclipse.org/legal/epl-v20.html
+
+# "license" property - text of the "Feature Update License"
+# should be plain text version of license agreement pointed to be "licenseURL"
+license=\
+Eclipse Public License - v 2.0\n\
+\n\
+    THE ACCOMPANYING PROGRAM IS PROVIDED UNDER THE TERMS OF THIS ECLIPSE\n\
+    PUBLIC LICENSE ("AGREEMENT"). ANY USE, REPRODUCTION OR DISTRIBUTION\n\
+    OF THE PROGRAM CONSTITUTES RECIPIENT'S ACCEPTANCE OF THIS AGREEMENT.\n\
+\n\
+1. DEFINITIONS\n\
+\n\
+"Contribution" means:\n\
+\n\
+  a) in the case of the initial Contributor, the initial content\n\
+     Distributed under this Agreement, and\n\
+\n\
+  b) in the case of each subsequent Contributor:\n\
+     i) changes to the Program, and\n\
+     ii) additions to the Program;\n\
+  where such changes and/or additions to the Program originate from\n\
+  and are Distributed by that particular Contributor. A Contribution\n\
+  "originates" from a Contributor if it was added to the Program by\n\
+  such Contributor itself or anyone acting on such Contributor's behalf.\n\
+  Contributions do not include changes or additions to the Program that\n\
+  are not Modified Works.\n\
+\n\
+"Contributor" means any person or entity that Distributes the Program.\n\
+\n\
+"Licensed Patents" mean patent claims licensable by a Contributor which\n\
+are necessarily infringed by the use or sale of its Contribution alone\n\
+or when combined with the Program.\n\
+\n\
+"Program" means the Contributions Distributed in accordance with this\n\
+Agreement.\n\
+\n\
+"Recipient" means anyone who receives the Program under this Agreement\n\
+or any Secondary License (as applicable), including Contributors.\n\
+\n\
+"Derivative Works" shall mean any work, whether in Source Code or other\n\
+form, that is based on (or derived from) the Program and for which the\n\
+editorial revisions, annotations, elaborations, or other modifications\n\
+represent, as a whole, an original work of authorship.\n\
+\n\
+"Modified Works" shall mean any work in Source Code or other form that\n\
+results from an addition to, deletion from, or modification of the\n\
+contents of the Program, including, for purposes of clarity any new file\n\
+in Source Code form that contains any contents of the Program. Modified\n\
+Works shall not include works that contain only declarations,\n\
+interfaces, types, classes, structures, or files of the Program solely\n\
+in each case in order to link to, bind by name, or subclass the Program\n\
+or Modified Works thereof.\n\
+\n\
+"Distribute" means the acts of a) distributing or b) making available\n\
+in any manner that enables the transfer of a copy.\n\
+\n\
+"Source Code" means the form of a Program preferred for making\n\
+modifications, including but not limited to software source code,\n\
+documentation source, and configuration files.\n\
+\n\
+"Secondary License" means either the GNU General Public License,\n\
+Version 2.0, or any later versions of that license, including any\n\
+exceptions or additional permissions as identified by the initial\n\
+Contributor.\n\
+\n\
+2. GRANT OF RIGHTS\n\
+\n\
+  a) Subject to the terms of this Agreement, each Contributor hereby\n\
+  grants Recipient a non-exclusive, worldwide, royalty-free copyright\n\
+  license to reproduce, prepare Derivative Works of, publicly display,\n\
+  publicly perform, Distribute and sublicense the Contribution of such\n\
+  Contributor, if any, and such Derivative Works.\n\
+\n\
+  b) Subject to the terms of this Agreement, each Contributor hereby\n\
+  grants Recipient a non-exclusive, worldwide, royalty-free patent\n\
+  license under Licensed Patents to make, use, sell, offer to sell,\n\
+  import and otherwise transfer the Contribution of such Contributor,\n\
+  if any, in Source Code or other form. This patent license shall\n\
+  apply to the combination of the Contribution and the Program if, at\n\
+  the time the Contribution is added by the Contributor, such addition\n\
+  of the Contribution causes such combination to be covered by the\n\
+  Licensed Patents. The patent license shall not apply to any other\n\
+  combinations which include the Contribution. No hardware per se is\n\
+  licensed hereunder.\n\
+\n\
+  c) Recipient understands that although each Contributor grants the\n\
+  licenses to its Contributions set forth herein, no assurances are\n\
+  provided by any Contributor that the Program does not infringe the\n\
+  patent or other intellectual property rights of any other entity.\n\
+  Each Contributor disclaims any liability to Recipient for claims\n\
+  brought by any other entity based on infringement of intellectual\n\
+  property rights or otherwise. As a condition to exercising the\n\
+  rights and licenses granted hereunder, each Recipient hereby\n\
+  assumes sole responsibility to secure any other intellectual\n\
+  property rights needed, if any. For example, if a third party\n\
+  patent license is required to allow Recipient to Distribute the\n\
+  Program, it is Recipient's responsibility to acquire that license\n\
+  before distributing the Program.\n\
+\n\
+  d) Each Contributor represents that to its knowledge it has\n\
+  sufficient copyright rights in its Contribution, if any, to grant\n\
+  the copyright license set forth in this Agreement.\n\
+\n\
+  e) Notwithstanding the terms of any Secondary License, no\n\
+  Contributor makes additional grants to any Recipient (other than\n\
+  those set forth in this Agreement) as a result of such Recipient's\n\
+  receipt of the Program under the terms of a Secondary License\n\
+  (if permitted under the terms of Section 3).\n\
+\n\
+3. REQUIREMENTS\n\
+\n\
+3.1 If a Contributor Distributes the Program in any form, then:\n\
+\n\
+  a) the Program must also be made available as Source Code, in\n\
+  accordance with section 3.2, and the Contributor must accompany\n\
+  the Program with a statement that the Source Code for the Program\n\
+  is available under this Agreement, and informs Recipients how to\n\
+  obtain it in a reasonable manner on or through a medium customarily\n\
+  used for software exchange; and\n\
+\n\
+  b) the Contributor may Distribute the Program under a license\n\
+  different than this Agreement, provided that such license:\n\
+     i) effectively disclaims on behalf of all other Contributors all\n\
+     warranties and conditions, express and implied, including\n\
+     warranties or conditions of title and non-infringement, and\n\
+     implied warranties or conditions of merchantability and fitness\n\
+     for a particular purpose;\n\
+\n\
+     ii) effectively excludes on behalf of all other Contributors all\n\
+     liability for damages, including direct, indirect, special,\n\
+     incidental and consequential damages, such as lost profits;\n\
+\n\
+     iii) does not attempt to limit or alter the recipients' rights\n\
+     in the Source Code under section 3.2; and\n\
+\n\
+     iv) requires any subsequent distribution of the Program by any\n\
+     party to be under a license that satisfies the requirements\n\
+     of this section 3.\n\
+\n\
+3.2 When the Program is Distributed as Source Code:\n\
+\n\
+  a) it must be made available under this Agreement, or if the\n\
+  Program (i) is combined with other material in a separate file or\n\
+  files made available under a Secondary License, and (ii) the initial\n\
+  Contributor attached to the Source Code the notice described in\n\
+  Exhibit A of this Agreement, then the Program may be made available\n\
+  under the terms of such Secondary Licenses, and\n\
+\n\
+  b) a copy of this Agreement must be included with each copy of\n\
+  the Program.\n\
+\n\
+3.3 Contributors may not remove or alter any copyright, patent,\n\
+trademark, attribution notices, disclaimers of warranty, or limitations\n\
+of liability ("notices") contained within the Program from any copy of\n\
+the Program which they Distribute, provided that Contributors may add\n\
+their own appropriate notices.\n\
+\n\
+4. COMMERCIAL DISTRIBUTION\n\
+\n\
+Commercial distributors of software may accept certain responsibilities\n\
+with respect to end users, business partners and the like. While this\n\
+license is intended to facilitate the commercial use of the Program,\n\
+the Contributor who includes the Program in a commercial product\n\
+offering should do so in a manner which does not create potential\n\
+liability for other Contributors. Therefore, if a Contributor includes\n\
+the Program in a commercial product offering, such Contributor\n\
+("Commercial Contributor") hereby agrees to defend and indemnify every\n\
+other Contributor ("Indemnified Contributor") against any losses,\n\
+damages and costs (collectively "Losses") arising from claims, lawsuits\n\
+and other legal actions brought by a third party against the Indemnified\n\
+Contributor to the extent caused by the acts or omissions of such\n\
+Commercial Contributor in connection with its distribution of the Program\n\
+in a commercial product offering. The obligations in this section do not\n\
+apply to any claims or Losses relating to any actual or alleged\n\
+intellectual property infringement. In order to qualify, an Indemnified\n\
+Contributor must: a) promptly notify the Commercial Contributor in\n\
+writing of such claim, and b) allow the Commercial Contributor to control,\n\
+and cooperate with the Commercial Contributor in, the defense and any\n\
+related settlement negotiations. The Indemnified Contributor may\n\
+participate in any such claim at its own expense.\n\
+\n\
+For example, a Contributor might include the Program in a commercial\n\
+product offering, Product X. That Contributor is then a Commercial\n\
+Contributor. If that Commercial Contributor then makes performance\n\
+claims, or offers warranties related to Product X, those performance\n\
+claims and warranties are such Commercial Contributor's responsibility\n\
+alone. Under this section, the Commercial Contributor would have to\n\
+defend claims against the other Contributors related to those performance\n\
+claims and warranties, and if a court requires any other Contributor to\n\
+pay any damages as a result, the Commercial Contributor must pay\n\
+those damages.\n\
+\n\
+5. NO WARRANTY\n\
+\n\
+EXCEPT AS EXPRESSLY SET FORTH IN THIS AGREEMENT, AND TO THE EXTENT\n\
+PERMITTED BY APPLICABLE LAW, THE PROGRAM IS PROVIDED ON AN "AS IS"\n\
+BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, EITHER EXPRESS OR\n\
+IMPLIED INCLUDING, WITHOUT LIMITATION, ANY WARRANTIES OR CONDITIONS OF\n\
+TITLE, NON-INFRINGEMENT, MERCHANTABILITY OR FITNESS FOR A PARTICULAR\n\
+PURPOSE. Each Recipient is solely responsible for determining the\n\
+appropriateness of using and distributing the Program and assumes all\n\
+risks associated with its exercise of rights under this Agreement,\n\
+including but not limited to the risks and costs of program errors,\n\
+compliance with applicable laws, damage to or loss of data, programs\n\
+or equipment, and unavailability or interruption of operations.\n\
+\n\
+6. DISCLAIMER OF LIABILITY\n\
+\n\
+EXCEPT AS EXPRESSLY SET FORTH IN THIS AGREEMENT, AND TO THE EXTENT\n\
+PERMITTED BY APPLICABLE LAW, NEITHER RECIPIENT NOR ANY CONTRIBUTORS\n\
+SHALL HAVE ANY LIABILITY FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL,\n\
+EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING WITHOUT LIMITATION LOST\n\
+PROFITS), HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN\n\
+CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)\n\
+ARISING IN ANY WAY OUT OF THE USE OR DISTRIBUTION OF THE PROGRAM OR THE\n\
+EXERCISE OF ANY RIGHTS GRANTED HEREUNDER, EVEN IF ADVISED OF THE\n\
+POSSIBILITY OF SUCH DAMAGES.\n\
+\n\
+7. GENERAL\n\
+\n\
+If any provision of this Agreement is invalid or unenforceable under\n\
+applicable law, it shall not affect the validity or enforceability of\n\
+the remainder of the terms of this Agreement, and without further\n\
+action by the parties hereto, such provision shall be reformed to the\n\
+minimum extent necessary to make such provision valid and enforceable.\n\
+\n\
+If Recipient institutes patent litigation against any entity\n\
+(including a cross-claim or counterclaim in a lawsuit) alleging that the\n\
+Program itself (excluding combinations of the Program with other software\n\
+or hardware) infringes such Recipient's patent(s), then such Recipient's\n\
+rights granted under Section 2(b) shall terminate as of the date such\n\
+litigation is filed.\n\
+\n\
+All Recipient's rights under this Agreement shall terminate if it\n\
+fails to comply with any of the material terms or conditions of this\n\
+Agreement and does not cure such failure in a reasonable period of\n\
+time after becoming aware of such noncompliance. If all Recipient's\n\
+rights under this Agreement terminate, Recipient agrees to cease use\n\
+and distribution of the Program as soon as reasonably practicable.\n\
+However, Recipient's obligations under this Agreement and any licenses\n\
+granted by Recipient relating to the Program shall continue and survive.\n\
+\n\
+Everyone is permitted to copy and distribute copies of this Agreement,\n\
+but in order to avoid inconsistency the Agreement is copyrighted and\n\
+may only be modified in the following manner. The Agreement Steward\n\
+reserves the right to publish new versions (including revisions) of\n\
+this Agreement from time to time. No one other than the Agreement\n\
+Steward has the right to modify this Agreement. The Eclipse Foundation\n\
+is the initial Agreement Steward. The Eclipse Foundation may assign the\n\
+responsibility to serve as the Agreement Steward to a suitable separate\n\
+entity. Each new version of the Agreement will be given a distinguishing\n\
+version number. The Program (including Contributions) may always be\n\
+Distributed subject to the version of the Agreement under which it was\n\
+received. In addition, after a new version of the Agreement is published,\n\
+Contributor may elect to Distribute the Program (including its\n\
+Contributions) under the new version.\n\
+\n\
+Except as expressly stated in Sections 2(a) and 2(b) above, Recipient\n\
+receives no rights or licenses to the intellectual property of any\n\
+Contributor under this Agreement, whether expressly, by implication,\n\
+estoppel or otherwise. All rights in the Program not expressly granted\n\
+under this Agreement are reserved. Nothing in this Agreement is intended\n\
+to be enforceable by any entity that is not a Contributor or Recipient.\n\
+No third-party beneficiary rights are created under this Agreement.\n\
+\n\
+Exhibit A - Form of Secondary Licenses Notice\n\
+\n\
+"This Source Code may also be made available under the following \n\
+Secondary Licenses when the conditions for such availability set forth \n\
+in the Eclipse Public License, v. 2.0 are satisfied: {name license(s),\n\
+version(s), and exceptions or additional permissions here}."\n\
+\n\
+  Simply including a copy of this Agreement, including this Exhibit A\n\
+  is not sufficient to license the Source Code under Secondary Licenses.\n\
+\n\
+  If it is not possible or desirable to put the notice in a particular\n\
+  file, then You may include the notice in a location (such as a LICENSE\n\
+  file in a relevant directory) where a recipient would be likely to\n\
+  look for such a notice.\n\
+\n\
+  You may add additional accurate notices of copyright ownership.\n
+########### end of license property ##########################################

--- a/features/org.palladiosimulator.license.epl2/feature.xml
+++ b/features/org.palladiosimulator.license.epl2/feature.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <feature
-      id="org.palladiosimulator.license"
+      id="org.palladiosimulator.license.epl2"
       version="1.0.0"
       provider-name="%providerName">
 

--- a/features/org.palladiosimulator.license.epl2/readme.txt
+++ b/features/org.palladiosimulator.license.epl2/readme.txt
@@ -1,0 +1,17 @@
+Shared License for Palladio Projects
+------------------------------------
+
+Author: Sebastian Lehrig
+Date: 2015/06/16
+
+Other features using this feature as a "shared license" will "inherit" the attributes
+configured in the feature.properties file.
+
+Limitations:
+- Does not work for the "sites to visit" attribute
+- Does not work for branding
+
+Additional information about shared licenses are here:
+http://relengofthenerds.blogspot.de/2011/01/implementing-shared-licenses-with-37m5.html
+http://help.eclipse.org/mars/index.jsp?topic=%2Forg.eclipse.pde.doc.user%2Ftasks%2Fpde_shared_license.htm
+

--- a/features/org.palladiosimulator.license/feature.properties
+++ b/features/org.palladiosimulator.license/feature.properties
@@ -12,9 +12,8 @@ copyrightURL=http://www.palladio-simulator.com/about_palladio/contact/
 # "copyright" property - text of the "Feature Update Copyright"
 copyright=\
 Palladio Bench, Palladio Component Model\n\
-Copyright 2005-2019,\n\
+Copyright 2005-2015,\n\
 Karlsruhe Institute of Technology (KIT), Software Design and Quality, Karlsruhe, Germany\n\
-University of Stuttgart, Institute of Software Technology, Stuttgart, Germany\n\
 Chemnitz University of Technology, Software Engineering Chair, Chemnitz, Germany\n\
 Paderborn University, Heinz Nixdorf Institute, Software Engineering, Paderborn, Germany\n\
 FZI Research Center for Information Technology, Karlsruhe, Germany\n\
@@ -23,286 +22,95 @@ http://www.palladio-simulator.com\n
 
 # "licenseURL" property - URL of the "Feature License"
 # do not translate value - just change to point to a locale-specific HTML page
-licenseURL=https://www.eclipse.org/legal/epl-v20.html
+licenseURL=http://www.eclipse.org/legal/epl-v10.html
 
 # "license" property - text of the "Feature Update License"
 # should be plain text version of license agreement pointed to be "licenseURL"
 license=\
-Eclipse Public License - v 2.0\n\
+Eclipse Public License - v 1.0\n\
 \n\
-    THE ACCOMPANYING PROGRAM IS PROVIDED UNDER THE TERMS OF THIS ECLIPSE\n\
-    PUBLIC LICENSE ("AGREEMENT"). ANY USE, REPRODUCTION OR DISTRIBUTION\n\
-    OF THE PROGRAM CONSTITUTES RECIPIENT'S ACCEPTANCE OF THIS AGREEMENT.\n\
+THE ACCOMPANYING PROGRAM IS PROVIDED UNDER THE TERMS OF THIS ECLIPSE PUBLIC LICENSE ("AGREEMENT"). ANY USE, REPRODUCTION OR DISTRIBUTION OF THE PROGRAM CONSTITUTES RECIPIENT'S ACCEPTANCE OF THIS AGREEMENT.\n\
 \n\
 1. DEFINITIONS\n\
 \n\
 "Contribution" means:\n\
 \n\
-  a) in the case of the initial Contributor, the initial content\n\
-     Distributed under this Agreement, and\n\
+a) in the case of the initial Contributor, the initial code and documentation distributed under this Agreement, and\n\
+b) in the case of each subsequent Contributor:\n\
 \n\
-  b) in the case of each subsequent Contributor:\n\
-     i) changes to the Program, and\n\
-     ii) additions to the Program;\n\
-  where such changes and/or additions to the Program originate from\n\
-  and are Distributed by that particular Contributor. A Contribution\n\
-  "originates" from a Contributor if it was added to the Program by\n\
-  such Contributor itself or anyone acting on such Contributor's behalf.\n\
-  Contributions do not include changes or additions to the Program that\n\
-  are not Modified Works.\n\
+i) changes to the Program, and\n\
 \n\
-"Contributor" means any person or entity that Distributes the Program.\n\
+ii) additions to the Program;\n\
 \n\
-"Licensed Patents" mean patent claims licensable by a Contributor which\n\
-are necessarily infringed by the use or sale of its Contribution alone\n\
-or when combined with the Program.\n\
+where such changes and/or additions to the Program originate from and are distributed by that particular Contributor. A Contribution 'originates' from a Contributor if it was added to the Program by such Contributor itself or anyone acting on such Contributor's behalf. Contributions do not include additions to the Program which: (i) are separate modules of software distributed in conjunction with the Program under their own license agreement, and (ii) are not derivative works of the Program.\n\
 \n\
-"Program" means the Contributions Distributed in accordance with this\n\
-Agreement.\n\
+"Contributor" means any person or entity that distributes the Program.\n\
 \n\
-"Recipient" means anyone who receives the Program under this Agreement\n\
-or any Secondary License (as applicable), including Contributors.\n\
+"Licensed Patents " mean patent claims licensable by a Contributor which are necessarily infringed by the use or sale of its Contribution alone or when combined with the Program.\n\
 \n\
-"Derivative Works" shall mean any work, whether in Source Code or other\n\
-form, that is based on (or derived from) the Program and for which the\n\
-editorial revisions, annotations, elaborations, or other modifications\n\
-represent, as a whole, an original work of authorship.\n\
+"Program" means the Contributions distributed in accordance with this Agreement.\n\
 \n\
-"Modified Works" shall mean any work in Source Code or other form that\n\
-results from an addition to, deletion from, or modification of the\n\
-contents of the Program, including, for purposes of clarity any new file\n\
-in Source Code form that contains any contents of the Program. Modified\n\
-Works shall not include works that contain only declarations,\n\
-interfaces, types, classes, structures, or files of the Program solely\n\
-in each case in order to link to, bind by name, or subclass the Program\n\
-or Modified Works thereof.\n\
-\n\
-"Distribute" means the acts of a) distributing or b) making available\n\
-in any manner that enables the transfer of a copy.\n\
-\n\
-"Source Code" means the form of a Program preferred for making\n\
-modifications, including but not limited to software source code,\n\
-documentation source, and configuration files.\n\
-\n\
-"Secondary License" means either the GNU General Public License,\n\
-Version 2.0, or any later versions of that license, including any\n\
-exceptions or additional permissions as identified by the initial\n\
-Contributor.\n\
+"Recipient" means anyone who receives the Program under this Agreement, including all Contributors.\n\
 \n\
 2. GRANT OF RIGHTS\n\
 \n\
-  a) Subject to the terms of this Agreement, each Contributor hereby\n\
-  grants Recipient a non-exclusive, worldwide, royalty-free copyright\n\
-  license to reproduce, prepare Derivative Works of, publicly display,\n\
-  publicly perform, Distribute and sublicense the Contribution of such\n\
-  Contributor, if any, and such Derivative Works.\n\
+a) Subject to the terms of this Agreement, each Contributor hereby grants Recipient a non-exclusive, worldwide, royalty-free copyright license to reproduce, prepare derivative works of, publicly display, publicly perform, distribute and sublicense the Contribution of such Contributor, if any, and such derivative works, in source code and object code form.\n\
 \n\
-  b) Subject to the terms of this Agreement, each Contributor hereby\n\
-  grants Recipient a non-exclusive, worldwide, royalty-free patent\n\
-  license under Licensed Patents to make, use, sell, offer to sell,\n\
-  import and otherwise transfer the Contribution of such Contributor,\n\
-  if any, in Source Code or other form. This patent license shall\n\
-  apply to the combination of the Contribution and the Program if, at\n\
-  the time the Contribution is added by the Contributor, such addition\n\
-  of the Contribution causes such combination to be covered by the\n\
-  Licensed Patents. The patent license shall not apply to any other\n\
-  combinations which include the Contribution. No hardware per se is\n\
-  licensed hereunder.\n\
+b) Subject to the terms of this Agreement, each Contributor hereby grants Recipient a non-exclusive, worldwide, royalty-free patent license under Licensed Patents to make, use, sell, offer to sell, import and otherwise transfer the Contribution of such Contributor, if any, in source code and object code form. This patent license shall apply to the combination of the Contribution and the Program if, at the time the Contribution is added by the Contributor, such addition of the Contribution causes such combination to be covered by the Licensed Patents. The patent license shall not apply to any other combinations which include the Contribution. No hardware per se is licensed hereunder.\n\
 \n\
-  c) Recipient understands that although each Contributor grants the\n\
-  licenses to its Contributions set forth herein, no assurances are\n\
-  provided by any Contributor that the Program does not infringe the\n\
-  patent or other intellectual property rights of any other entity.\n\
-  Each Contributor disclaims any liability to Recipient for claims\n\
-  brought by any other entity based on infringement of intellectual\n\
-  property rights or otherwise. As a condition to exercising the\n\
-  rights and licenses granted hereunder, each Recipient hereby\n\
-  assumes sole responsibility to secure any other intellectual\n\
-  property rights needed, if any. For example, if a third party\n\
-  patent license is required to allow Recipient to Distribute the\n\
-  Program, it is Recipient's responsibility to acquire that license\n\
-  before distributing the Program.\n\
+c) Recipient understands that although each Contributor grants the licenses to its Contributions set forth herein, no assurances are provided by any Contributor that the Program does not infringe the patent or other intellectual property rights of any other entity. Each Contributor disclaims any liability to Recipient for claims brought by any other entity based on infringement of intellectual property rights or otherwise. As a condition to exercising the rights and licenses granted hereunder, each Recipient hereby assumes sole responsibility to secure any other intellectual property rights needed, if any. For example, if a third party patent license is required to allow Recipient to distribute the Program, it is Recipient's responsibility to acquire that license before distributing the Program.\n\
 \n\
-  d) Each Contributor represents that to its knowledge it has\n\
-  sufficient copyright rights in its Contribution, if any, to grant\n\
-  the copyright license set forth in this Agreement.\n\
-\n\
-  e) Notwithstanding the terms of any Secondary License, no\n\
-  Contributor makes additional grants to any Recipient (other than\n\
-  those set forth in this Agreement) as a result of such Recipient's\n\
-  receipt of the Program under the terms of a Secondary License\n\
-  (if permitted under the terms of Section 3).\n\
+d) Each Contributor represents that to its knowledge it has sufficient copyright rights in its Contribution, if any, to grant the copyright license set forth in this Agreement.\n\
 \n\
 3. REQUIREMENTS\n\
 \n\
-3.1 If a Contributor Distributes the Program in any form, then:\n\
+A Contributor may choose to distribute the Program in object code form under its own license agreement, provided that:\n\
 \n\
-  a) the Program must also be made available as Source Code, in\n\
-  accordance with section 3.2, and the Contributor must accompany\n\
-  the Program with a statement that the Source Code for the Program\n\
-  is available under this Agreement, and informs Recipients how to\n\
-  obtain it in a reasonable manner on or through a medium customarily\n\
-  used for software exchange; and\n\
+a) it complies with the terms and conditions of this Agreement; and\n\
 \n\
-  b) the Contributor may Distribute the Program under a license\n\
-  different than this Agreement, provided that such license:\n\
-     i) effectively disclaims on behalf of all other Contributors all\n\
-     warranties and conditions, express and implied, including\n\
-     warranties or conditions of title and non-infringement, and\n\
-     implied warranties or conditions of merchantability and fitness\n\
-     for a particular purpose;\n\
+b) its license agreement:\n\
 \n\
-     ii) effectively excludes on behalf of all other Contributors all\n\
-     liability for damages, including direct, indirect, special,\n\
-     incidental and consequential damages, such as lost profits;\n\
+i) effectively disclaims on behalf of all Contributors all warranties and conditions, express and implied, including warranties or conditions of title and non-infringement, and implied warranties or conditions of merchantability and fitness for a particular purpose;\n\
 \n\
-     iii) does not attempt to limit or alter the recipients' rights\n\
-     in the Source Code under section 3.2; and\n\
+ii) effectively excludes on behalf of all Contributors all liability for damages, including direct, indirect, special, incidental and consequential damages, such as lost profits;\n\
 \n\
-     iv) requires any subsequent distribution of the Program by any\n\
-     party to be under a license that satisfies the requirements\n\
-     of this section 3.\n\
+iii) states that any provisions which differ from this Agreement are offered by that Contributor alone and not by any other party; and\n\
 \n\
-3.2 When the Program is Distributed as Source Code:\n\
+iv) states that source code for the Program is available from such Contributor, and informs licensees how to obtain it in a reasonable manner on or through a medium customarily used for software exchange.\n\
 \n\
-  a) it must be made available under this Agreement, or if the\n\
-  Program (i) is combined with other material in a separate file or\n\
-  files made available under a Secondary License, and (ii) the initial\n\
-  Contributor attached to the Source Code the notice described in\n\
-  Exhibit A of this Agreement, then the Program may be made available\n\
-  under the terms of such Secondary Licenses, and\n\
+When the Program is made available in source code form:\n\
 \n\
-  b) a copy of this Agreement must be included with each copy of\n\
-  the Program.\n\
+a) it must be made available under this Agreement; and\n\
 \n\
-3.3 Contributors may not remove or alter any copyright, patent,\n\
-trademark, attribution notices, disclaimers of warranty, or limitations\n\
-of liability ("notices") contained within the Program from any copy of\n\
-the Program which they Distribute, provided that Contributors may add\n\
-their own appropriate notices.\n\
+b) a copy of this Agreement must be included with each copy of the Program.\n\
+\n\
+Contributors may not remove or alter any copyright notices contained within the Program.\n\
+\n\
+Each Contributor must identify itself as the originator of its Contribution, if any, in a manner that reasonably allows subsequent Recipients to identify the originator of the Contribution.\n\
 \n\
 4. COMMERCIAL DISTRIBUTION\n\
 \n\
-Commercial distributors of software may accept certain responsibilities\n\
-with respect to end users, business partners and the like. While this\n\
-license is intended to facilitate the commercial use of the Program,\n\
-the Contributor who includes the Program in a commercial product\n\
-offering should do so in a manner which does not create potential\n\
-liability for other Contributors. Therefore, if a Contributor includes\n\
-the Program in a commercial product offering, such Contributor\n\
-("Commercial Contributor") hereby agrees to defend and indemnify every\n\
-other Contributor ("Indemnified Contributor") against any losses,\n\
-damages and costs (collectively "Losses") arising from claims, lawsuits\n\
-and other legal actions brought by a third party against the Indemnified\n\
-Contributor to the extent caused by the acts or omissions of such\n\
-Commercial Contributor in connection with its distribution of the Program\n\
-in a commercial product offering. The obligations in this section do not\n\
-apply to any claims or Losses relating to any actual or alleged\n\
-intellectual property infringement. In order to qualify, an Indemnified\n\
-Contributor must: a) promptly notify the Commercial Contributor in\n\
-writing of such claim, and b) allow the Commercial Contributor to control,\n\
-and cooperate with the Commercial Contributor in, the defense and any\n\
-related settlement negotiations. The Indemnified Contributor may\n\
-participate in any such claim at its own expense.\n\
+Commercial distributors of software may accept certain responsibilities with respect to end users, business partners and the like. While this license is intended to facilitate the commercial use of the Program, the Contributor who includes the Program in a commercial product offering should do so in a manner which does not create potential liability for other Contributors. Therefore, if a Contributor includes the Program in a commercial product offering, such Contributor ("Commercial Contributor") hereby agrees to defend and indemnify every other Contributor ("Indemnified Contributor") against any losses, damages and costs (collectively "Losses") arising from claims, lawsuits and other legal actions brought by a third party against the Indemnified Contributor to the extent caused by the acts or omissions of such Commercial Contributor in connection with its distribution of the Program in a commercial product offering. The obligations in this section do not apply to any claims or Losses relating to any actual or alleged intellectual property infringement. In order to qualify, an Indemnified Contributor must: a) promptly notify the Commercial Contributor in writing of such claim, and b) allow the Commercial Contributor to control, and cooperate with the Commercial Contributor in, the defense and any related settlement negotiations. The Indemnified Contributor may participate in any such claim at its own expense.\n\
 \n\
-For example, a Contributor might include the Program in a commercial\n\
-product offering, Product X. That Contributor is then a Commercial\n\
-Contributor. If that Commercial Contributor then makes performance\n\
-claims, or offers warranties related to Product X, those performance\n\
-claims and warranties are such Commercial Contributor's responsibility\n\
-alone. Under this section, the Commercial Contributor would have to\n\
-defend claims against the other Contributors related to those performance\n\
-claims and warranties, and if a court requires any other Contributor to\n\
-pay any damages as a result, the Commercial Contributor must pay\n\
-those damages.\n\
+For example, a Contributor might include the Program in a commercial product offering, Product X. That Contributor is then a Commercial Contributor. If that Commercial Contributor then makes performance claims, or offers warranties related to Product X, those performance claims and warranties are such Commercial Contributor's responsibility alone. Under this section, the Commercial Contributor would have to defend claims against the other Contributors related to those performance claims and warranties, and if a court requires any other Contributor to pay any damages as a result, the Commercial Contributor must pay those damages.\n\
 \n\
 5. NO WARRANTY\n\
 \n\
-EXCEPT AS EXPRESSLY SET FORTH IN THIS AGREEMENT, AND TO THE EXTENT\n\
-PERMITTED BY APPLICABLE LAW, THE PROGRAM IS PROVIDED ON AN "AS IS"\n\
-BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, EITHER EXPRESS OR\n\
-IMPLIED INCLUDING, WITHOUT LIMITATION, ANY WARRANTIES OR CONDITIONS OF\n\
-TITLE, NON-INFRINGEMENT, MERCHANTABILITY OR FITNESS FOR A PARTICULAR\n\
-PURPOSE. Each Recipient is solely responsible for determining the\n\
-appropriateness of using and distributing the Program and assumes all\n\
-risks associated with its exercise of rights under this Agreement,\n\
-including but not limited to the risks and costs of program errors,\n\
-compliance with applicable laws, damage to or loss of data, programs\n\
-or equipment, and unavailability or interruption of operations.\n\
+EXCEPT AS EXPRESSLY SET FORTH IN THIS AGREEMENT, THE PROGRAM IS PROVIDED ON AN "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, EITHER EXPRESS OR IMPLIED INCLUDING, WITHOUT LIMITATION, ANY WARRANTIES OR CONDITIONS OF TITLE, NON-INFRINGEMENT, MERCHANTABILITY OR FITNESS FOR A PARTICULAR PURPOSE. Each Recipient is solely responsible for determining the appropriateness of using and distributing the Program and assumes all risks associated with its exercise of rights under this Agreement , including but not limited to the risks and costs of program errors, compliance with applicable laws, damage to or loss of data, programs or equipment, and unavailability or interruption of operations.\n\
 \n\
 6. DISCLAIMER OF LIABILITY\n\
 \n\
-EXCEPT AS EXPRESSLY SET FORTH IN THIS AGREEMENT, AND TO THE EXTENT\n\
-PERMITTED BY APPLICABLE LAW, NEITHER RECIPIENT NOR ANY CONTRIBUTORS\n\
-SHALL HAVE ANY LIABILITY FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL,\n\
-EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING WITHOUT LIMITATION LOST\n\
-PROFITS), HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN\n\
-CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)\n\
-ARISING IN ANY WAY OUT OF THE USE OR DISTRIBUTION OF THE PROGRAM OR THE\n\
-EXERCISE OF ANY RIGHTS GRANTED HEREUNDER, EVEN IF ADVISED OF THE\n\
-POSSIBILITY OF SUCH DAMAGES.\n\
+EXCEPT AS EXPRESSLY SET FORTH IN THIS AGREEMENT, NEITHER RECIPIENT NOR ANY CONTRIBUTORS SHALL HAVE ANY LIABILITY FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING WITHOUT LIMITATION LOST PROFITS), HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OR DISTRIBUTION OF THE PROGRAM OR THE EXERCISE OF ANY RIGHTS GRANTED HEREUNDER, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGES.\n\
 \n\
 7. GENERAL\n\
 \n\
-If any provision of this Agreement is invalid or unenforceable under\n\
-applicable law, it shall not affect the validity or enforceability of\n\
-the remainder of the terms of this Agreement, and without further\n\
-action by the parties hereto, such provision shall be reformed to the\n\
-minimum extent necessary to make such provision valid and enforceable.\n\
+If any provision of this Agreement is invalid or unenforceable under applicable law, it shall not affect the validity or enforceability of the remainder of the terms of this Agreement, and without further action by the parties hereto, such provision shall be reformed to the minimum extent necessary to make such provision valid and enforceable.\n\
 \n\
-If Recipient institutes patent litigation against any entity\n\
-(including a cross-claim or counterclaim in a lawsuit) alleging that the\n\
-Program itself (excluding combinations of the Program with other software\n\
-or hardware) infringes such Recipient's patent(s), then such Recipient's\n\
-rights granted under Section 2(b) shall terminate as of the date such\n\
-litigation is filed.\n\
+If Recipient institutes patent litigation against any entity (including a cross-claim or counterclaim in a lawsuit) alleging that the Program itself (excluding combinations of the Program with other software or hardware) infringes such Recipient's patent(s), then such Recipient's rights granted under Section 2(b) shall terminate as of the date such litigation is filed.\n\
 \n\
-All Recipient's rights under this Agreement shall terminate if it\n\
-fails to comply with any of the material terms or conditions of this\n\
-Agreement and does not cure such failure in a reasonable period of\n\
-time after becoming aware of such noncompliance. If all Recipient's\n\
-rights under this Agreement terminate, Recipient agrees to cease use\n\
-and distribution of the Program as soon as reasonably practicable.\n\
-However, Recipient's obligations under this Agreement and any licenses\n\
-granted by Recipient relating to the Program shall continue and survive.\n\
+All Recipient's rights under this Agreement shall terminate if it fails to comply with any of the material terms or conditions of this Agreement and does not cure such failure in a reasonable period of time after becoming aware of such noncompliance. If all Recipient's rights under this Agreement terminate, Recipient agrees to cease use and distribution of the Program as soon as reasonably practicable. However, Recipient's obligations under this Agreement and any licenses granted by Recipient relating to the Program shall continue and survive.\n\
 \n\
-Everyone is permitted to copy and distribute copies of this Agreement,\n\
-but in order to avoid inconsistency the Agreement is copyrighted and\n\
-may only be modified in the following manner. The Agreement Steward\n\
-reserves the right to publish new versions (including revisions) of\n\
-this Agreement from time to time. No one other than the Agreement\n\
-Steward has the right to modify this Agreement. The Eclipse Foundation\n\
-is the initial Agreement Steward. The Eclipse Foundation may assign the\n\
-responsibility to serve as the Agreement Steward to a suitable separate\n\
-entity. Each new version of the Agreement will be given a distinguishing\n\
-version number. The Program (including Contributions) may always be\n\
-Distributed subject to the version of the Agreement under which it was\n\
-received. In addition, after a new version of the Agreement is published,\n\
-Contributor may elect to Distribute the Program (including its\n\
-Contributions) under the new version.\n\
+Everyone is permitted to copy and distribute copies of this Agreement, but in order to avoid inconsistency the Agreement is copyrighted and may only be modified in the following manner. The Agreement Steward reserves the right to publish new versions (including revisions) of this Agreement from time to time. No one other than the Agreement Steward has the right to modify this Agreement. The Eclipse Foundation is the initial Agreement Steward. The Eclipse Foundation may assign the responsibility to serve as the Agreement Steward to a suitable separate entity. Each new version of the Agreement will be given a distinguishing version number. The Program (including Contributions) may always be distributed subject to the version of the Agreement under which it was received. In addition, after a new version of the Agreement is published, Contributor may elect to distribute the Program (including its Contributions) under the new version. Except as expressly stated in Sections 2(a) and 2(b) above, Recipient receives no rights or licenses to the intellectual property of any Contributor under this Agreement, whether expressly, by implication, estoppel or otherwise. All rights in the Program not expressly granted under this Agreement are reserved.\n\
 \n\
-Except as expressly stated in Sections 2(a) and 2(b) above, Recipient\n\
-receives no rights or licenses to the intellectual property of any\n\
-Contributor under this Agreement, whether expressly, by implication,\n\
-estoppel or otherwise. All rights in the Program not expressly granted\n\
-under this Agreement are reserved. Nothing in this Agreement is intended\n\
-to be enforceable by any entity that is not a Contributor or Recipient.\n\
-No third-party beneficiary rights are created under this Agreement.\n\
-\n\
-Exhibit A - Form of Secondary Licenses Notice\n\
-\n\
-"This Source Code may also be made available under the following \n\
-Secondary Licenses when the conditions for such availability set forth \n\
-in the Eclipse Public License, v. 2.0 are satisfied: {name license(s),\n\
-version(s), and exceptions or additional permissions here}."\n\
-\n\
-  Simply including a copy of this Agreement, including this Exhibit A\n\
-  is not sufficient to license the Source Code under Secondary Licenses.\n\
-\n\
-  If it is not possible or desirable to put the notice in a particular\n\
-  file, then You may include the notice in a location (such as a LICENSE\n\
-  file in a relevant directory) where a recipient would be likely to\n\
-  look for such a notice.\n\
-\n\
-  You may add additional accurate notices of copyright ownership.\n
+This Agreement is governed by the laws of the State of New York and the intellectual property laws of the United States of America. No party to this Agreement will bring a legal action under this Agreement more than one year after the cause of action arose. Each party waives its rights to a jury trial in any resulting litigation.\n
 ########### end of license property ##########################################

--- a/features/pom.xml
+++ b/features/pom.xml
@@ -13,6 +13,7 @@
 	
 	<modules>
 		<module>org.palladiosimulator.license</module>
+		<module>org.palladiosimulator.license.epl2</module>
 		<module>org.palladiosimulator.branding.feature</module>
 	</modules>
 	

--- a/pom.xml
+++ b/pom.xml
@@ -6,7 +6,7 @@
 	<parent>
 		<groupId>tools.mdsd</groupId>
 		<artifactId>eclipse-parent-updatesite</artifactId>
-		<version>0.1.0</version>
+		<version>0.1.3</version>
 	</parent>
 	<groupId>org.palladiosimulator.branding</groupId>
 	<artifactId>parent</artifactId>	

--- a/releng/org.palladiosimulator.branding.updatesite/category.xml
+++ b/releng/org.palladiosimulator.branding.updatesite/category.xml
@@ -1,17 +1,23 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <site>
-	<feature url="features/org.palladiosimulator.branding.feature_2.0.0.jar" id="org.palladiosimulator.branding.feature" version="2.0.0">
-		<category name="pcm-branding"/>
-	</feature>
-	<feature url="features/org.palladiosimulator.license_2.0.0.jar" id="org.palladiosimulator.license" version="2.0.0">
-		<category name="pcm-branding"/>
-	</feature>
-	<feature url="features/org.palladiosimulator.branding.feature.source_2.0.0.jar" id="org.palladiosimulator.branding.feature.source" version="2.0.0">
-		<category name="pcm-branding-source"/>
-	</feature>
-	<feature url="features/org.palladiosimulator.license.source_2.0.0.jar" id="org.palladiosimulator.license.source" version="2.0.0">
-		<category name="pcm-branding-source"/>
-	</feature>
-	<category-def name="pcm-branding" label="Palladio Simulator Branding"/>
-	<category-def name="pcm-branding-source" label="Palladio Simulator Branding Developer Resources"/>
+   <feature url="features/org.palladiosimulator.branding.feature_2.0.0.jar" id="org.palladiosimulator.branding.feature" version="2.0.0">
+      <category name="pcm-branding"/>
+   </feature>
+   <feature url="features/org.palladiosimulator.branding.feature.source_2.0.0.jar" id="org.palladiosimulator.branding.feature.source" version="2.0.0">
+      <category name="pcm-branding-source"/>
+   </feature>
+   <feature url="features/org.palladiosimulator.license_1.0.0.jar" id="org.palladiosimulator.license" version="1.0.0">
+      <category name="pcm-branding"/>
+   </feature>
+   <feature url="features/org.palladiosimulator.license.source_1.0.0.jar" id="org.palladiosimulator.license" version="1.0.0">
+      <category name="pcm-branding-source"/>
+   </feature>
+   <feature url="features/org.palladiosimulator.license.epl2_1.0.0.jar" id="org.palladiosimulator.license.epl2" version="1.0.0">
+      <category name="pcm-branding"/>
+   </feature>
+   <feature url="features/org.palladiosimulator.license.epl2.source_1.0.0.jar" id="org.palladiosimulator.license.epl2" version="1.0.0">
+      <category name="pcm-branding-source"/>
+   </feature>
+   <category-def name="pcm-branding" label="Palladio Simulator Branding"/>
+   <category-def name="pcm-branding-source" label="Palladio Simulator Branding Developer Resources"/>
 </site>


### PR DESCRIPTION
The PR reverts the changes of the latest commits and restores the EPL license of the license feature. In addition, I added a new license feature that hosts the EPL2 license. The branding feature does not refer to the license feature anymore.