### PR TITLE
Migrate to parent POM version 0.10.0

### DIFF
--- a/.mvn/extensions.xml
+++ b/.mvn/extensions.xml
@@ -5,10 +5,4 @@
 		<artifactId>tycho-build</artifactId>
 		<version>2.7.5</version>
 	</extension>
-	<extension>
-		<groupId>org.palladiosimulator</groupId>
-		<artifactId>tycho-tp-refresh-maven-plugin</artifactId>
-		<version>0.2.6</version>
-	</extension>
-
 </extensions>

--- a/pom.xml
+++ b/pom.xml
@@ -4,14 +4,18 @@
 		
 	<modelVersion>4.0.0</modelVersion>
 	<parent>
-		<groupId>tools.mdsd</groupId>
+		<groupId>org.palladiosimulator</groupId>
 		<artifactId>eclipse-parent-updatesite</artifactId>
-		<version>0.8.9</version>
+		<version>0.10.0</version>
 	</parent>
 	<groupId>org.palladiosimulator.branding</groupId>
 	<artifactId>parent</artifactId>	
 	<version>0.1.0-SNAPSHOT</version>
 	<packaging>pom</packaging>
+
+	<properties>
+		<targetPlatform.relativePath>releng/org.palladiosimulator.branding.targetplatform/tp.target</targetPlatform.relativePath>
+	</properties>
 	
 	<modules>
 		<module>bundles</module>

--- a/releng/org.palladiosimulator.branding.targetplatform/.project
+++ b/releng/org.palladiosimulator.branding.targetplatform/.project
@@ -1,0 +1,11 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<projectDescription>
+	<name>org.palladiosimulator.branding.targetplatform</name>
+	<comment></comment>
+	<projects>
+	</projects>
+	<buildSpec>
+	</buildSpec>
+	<natures>
+	</natures>
+</projectDescription>

--- a/releng/org.palladiosimulator.branding.targetplatform/tp.target
+++ b/releng/org.palladiosimulator.branding.targetplatform/tp.target
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8" standalone="no"?>
-<?pde version="3.8"?><target name="Palladio 2023-03">
+<?pde version="3.8"?><target name="org.palladiosimulator.branding Target Platform" sequenceNumber="1">
 	<locations>
 		<location includeAllPlatforms="false" includeConfigurePhase="true" includeMode="planner" includeSource="false" type="InstallableUnit">
 			<repository location="https://download.eclipse.org/releases/2023-03/202303151000/"/>

--- a/releng/org.palladiosimulator.branding.targetplatform/tp.target
+++ b/releng/org.palladiosimulator.branding.targetplatform/tp.target
@@ -1,0 +1,9 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<?pde version="3.8"?><target name="Palladio 2023-03">
+	<locations>
+		<location includeAllPlatforms="false" includeConfigurePhase="true" includeMode="planner" includeSource="false" type="InstallableUnit">
+			<repository location="https://download.eclipse.org/releases/2023-03/202303151000/"/>
+			<unit id="org.eclipse.platform.feature.group" version="0.0.0"/>
+		</location>
+	</locations>
+</target>


### PR DESCRIPTION
- Migrate from parent POM version `0.8.9` to the new parent POM version `0.10.0` and switch from `tools.mdsd:eclipse-parent-updatesite` to `org.palladiosimulator:eclipse-parent-updatesite`
- Create target platform
- Locally verified build success